### PR TITLE
Add Privacy Policy generated with ChatGPT for LinkedIn Developer App creation

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -191,7 +191,14 @@ func main() {
 		StaticFile("/humans.txt", "./public/humans.txt").
 		StaticFile("/robots.txt", "./public/robots.txt").
 		StaticFile("/manifest.json", "./public/manifest.json").
-		StaticFile("/browserconfig.xml", "./public/browserconfig.xml")
+		StaticFile("/browserconfig.xml", "./public/browserconfig.xml").
+
+		// Privacy policy aliases
+		// https://dou.ua/privacy/
+		// https://privacy.xing.com/en/privacy-policy
+		// https://www.linkedin.com/legal/privacy-policy
+		// https://www.facebook.com/privacy/policy/
+		StaticFile("privacy-policy", "./public/privacy-policy.html")
 
 	{
 		// very fast solution

--- a/public/privacy-policy.html
+++ b/public/privacy-policy.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Privacy Policy - ReadyToTouch</title>
+    <meta name="description" content="Yet another anonymous work search">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <link rel="author" type="text/plain" href="https://readytotouch.com/humans.txt"/>
+
+    <link rel="apple-touch-icon" sizes="57x57" href="/apple-icon-57x57.png">
+    <link rel="apple-touch-icon" sizes="60x60" href="/apple-icon-60x60.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="/apple-icon-72x72.png">
+    <link rel="apple-touch-icon" sizes="76x76" href="/apple-icon-76x76.png">
+    <link rel="apple-touch-icon" sizes="114x114" href="/apple-icon-114x114.png">
+    <link rel="apple-touch-icon" sizes="120x120" href="/apple-icon-120x120.png">
+    <link rel="apple-touch-icon" sizes="144x144" href="/apple-icon-144x144.png">
+    <link rel="apple-touch-icon" sizes="152x152" href="/apple-icon-152x152.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-icon-180x180.png">
+    <link rel="icon" type="image/png" sizes="192x192"  href="/android-icon-192x192.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+    <link rel="manifest" href="/manifest.json">
+    <meta name="msapplication-TileColor" content="#ffffff">
+    <meta name="msapplication-TileImage" content="/ms-icon-144x144.png">
+    <meta name="theme-color" content="#ffffff">
+
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            background-color: #f9f9f9;
+            margin: 0;
+            padding: 0;
+            color: #333;
+        }
+        .container {
+            max-width: 800px;
+            margin: 30px auto;
+            padding: 20px;
+            background-color: #fff;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+            border-radius: 8px;
+        }
+        h1 {
+            text-align: center;
+            color: #4CAF50;
+        }
+        h2 {
+            color: #333;
+            border-bottom: 2px solid #4CAF50;
+            padding-bottom: 5px;
+            margin-top: 30px;
+        }
+        p {
+            margin: 20px 0;
+        }
+        .version-date {
+            text-align: center;
+            font-style: italic;
+            color: #777;
+            margin-bottom: 40px;
+        }
+    </style>
+</head>
+<body>
+
+<div class="container">
+    <h1>Privacy Policy</h1>
+    <p class="version-date">Version 0.0.1 | Effective Date: 23 August 2024</p>
+
+    <h2>1. Information We Collect</h2>
+    <p>ReadyToTouch only collects the following personal information:</p>
+    <ul>
+        <li><strong>Email Address</strong>: This is collected solely for the purpose of identifying you when you log in through GitHub, GitLab, or Bitbucket. We do not collect, store, or process any other personal information.</li>
+    </ul>
+
+    <h2>2. Use of Collected Information</h2>
+    <p>The email address you provide is used exclusively for authentication purposes. ReadyToTouch does not use your email for marketing, advertising, or any other purposes.</p>
+
+    <h2>3. Legal Disclaimer</h2>
+    <p>ReadyToTouch is a pet project and is not legally registered as a company. This means that ReadyToTouch is operated without any formal corporate structure or legal entity. As a result, we disclaim any liability that may arise in connection with the use of this website.</p>
+
+    <h2>4. Changes to This Privacy Policy</h2>
+    <p>We may update this Privacy Policy from time to time. Any changes will be reflected in the version number and effective date at the top of this document. We encourage you to review this Privacy Policy periodically to stay informed about how we are protecting your information.</p>
+
+    <h2>5. Contact Us</h2>
+    <p>If you have any questions or concerns about this Privacy Policy, please contact us via <a href="https://www.linkedin.com/in/yaroslav-podorvanov/" target="_blank">LinkedIn</a>.</p>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
Page https://www.linkedin.com/developers/apps/new

### Path examples:
- https://www.linkedin.com/legal/privacy-policy
- https://privacy.xing.com/en/privacy-policy
- https://www.facebook.com/privacy/policy/
- https://dou.ua/privacy/