### PR TITLE
Fix the test helper function by adding the missing assertion

### DIFF
--- a/internal/db/postgres/online_storage_test.go
+++ b/internal/db/postgres/online_storage_test.go
@@ -178,6 +178,7 @@ func expectedHourlyStats(t *testing.T, ctx context.Context, connection *sql.DB, 
 	defer database.Queries().Close()
 
 	actualPairs, err := database.Queries().UserOnlineHourlyStats(ctx)
+	require.NoError(t, err)
 
 	hourlyActualPairs := make([]domain.UserOnlinePair, len(actualPairs))
 	for i, pair := range actualPairs {


### PR DESCRIPTION
The PR fixes the test helper function `expectedHourlyStats` by adding the missing `require.NoError(t, err)`.